### PR TITLE
docs(ADDRESSING): default DNSLink to ipfs://

### DIFF
--- a/ADDRESSING.md
+++ b/ADDRESSING.md
@@ -25,6 +25,7 @@ If no native protocol handler is available, redirect to a gateway:
 ```bash
 ipfs://{cid}                → https://{gateway}/ipfs/{cid}
 ipns://{libp2p-key}         → https://{gateway}/ipns/{libp2p-key}
+ipfs://{fqdn-with-dnslink}  → https://{gateway}/ipns/{fqdn-with-dnslink}
 ipns://{fqdn-with-dnslink}  → https://{gateway}/ipns/{fqdn-with-dnslink}
 ```
 
@@ -37,8 +38,8 @@ ipfs://{cidv0} → redirect → ipfs://{cidv1base32} # CIDv0 is case-sensitive B
 ipns://{libp2p-key-in-cidv1base32}
 ipns://{libp2p-key-in-base58} → redirect → ipns://{libp2p-key-in-cidv1}  # Base58, does not work as Origin authority
 
-ipns://{fqdn-with-dnslink}
-ipfs://{fqdn-with-dnslink} → redirect → ipns://{fqdn-with-dnslink} # just to improve UX :-)
+ipfs://{fqdn-with-dnslink}
+ipns://{fqdn-with-dnslink} → redirect → ipfs://{fqdn-with-dnslink} # just to improve UX :-)
 
 dweb:/ipfs/{root}/{resource} → redirect →  ipfs://{root}/{resource}  # ensures {root} is the authority component
 dweb:/ipns/{root}/{resource} → redirect →  ipns://{root}/{resource}  # ensures {root} is the authority component
@@ -76,10 +77,12 @@ Read more: [notes on addressing with HTTP](#notes-on-addressing-with-http).
 In future, subdomain convention will be replaced with native handler that provides the same origin-based guarantees:
 
     ipfs://{cidv1b32}/path/to/resource
+    ipfs://{fqdn-with-dnslink}/path/to/resource
 
 Example:
 
     ipfs://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq/wiki/Vincent_van_Gogh.html
+    ipfs://tr.wikipedia-on-ipfs.org/wiki/Vincent_van_Gogh.html
 
 Read more: [notes on addressing with ipfs://](#notes-on-addressing-with-ipfs).
 


### PR DESCRIPTION
> #### This PR proposes that `ipfs://{dnslink-fqdn}` becomes the default URL representation of DNSLink websites in web browsers


## Motivation 

Interesting quirk of where we are right now: 
DNSLink resides under `/ipns/{fqdn}`, but it is not related to IPNS in any way.  

I was thinking about the future, when we have protocol handlers in web browsers and what will be shown in address bar. 

Then I realized 1:1 mapping will show all DNSLink websites under `ipns://{fqdn}` :scream: 




## Proposed change



##### To avoid the future of `ipns://` we need to support DNSlink websites under `ipfs://{fqdn}`, and make `ipns://{fqdn}`  a redirect to `ipfs://{fqdn}`.

It is easy to implement:
- IF valid `{cid}`, load it
- ELSE IF DNSLink record exists for `{fqdn}`, resolve it and load the content
- ELSE return "invalid address" error

This will solve a set of problems:
- people being confused why "IPFS websites" are on `ipns://` instead of `ipfs://`
- future-proofing: in the long run, we will keep supporting `/ipns/{fqdn}`, but will probably end up switching DNSLink to its own namespace at `/dnslink/{fqdn}` (https://github.com/ipfs/notes/issues/348#issuecomment-514391990). Detaching default from `ipns://` now, saves us headache later
- removing the problem of cross-protocol  boundary on DNSLink websites (https://github.com/mozilla/libdweb/issues/52)
  - **tl;dr** this is a big security issue, as cross-protocol rules are undefined and vendors default to blocking such requests ("better safe than sorry")
  - DNSLink website could be backed by any IPNS content path in DNS TXT record which enables cross-protocol on the IPFS side, without mixing protocol handlers in web browser

### What about ipns:// ?

It would remain and work for real IPNS paths. We would still support DNSLink on it, but as a redirect to `ipfs://` URL. I imagine loading websites via "raw IPNS" (`ipns://{libp2p-key}`) will be pretty rare event and similar to loading website via raw IP (bad UX, but works without DNS).


cc #147 