### PR TITLE
docs: add test for ipfs:// origin isolation

### DIFF
--- a/docs/ipfs-protocol-handler-support-tests.html
+++ b/docs/ipfs-protocol-handler-support-tests.html
@@ -51,7 +51,7 @@
       <div class='db pb1 w-100 fw2 tracked ttu f3 teal-muted link'>
         ORIGIN ISOLATION
       </div>
-      <p>Open diagnostic page at <a href="ipfs://bafkreiatfi5jmy2gzhjr5tixsqntof3pieuyibcbaz3riakaepx4ytoxfu" class="f4 link navy hover-teal link underline">ipfs://bafkreiatfi5jmy2gzhjr5tixsqntof3pieuyibcbaz3riakaepx4ytoxfu</a></p>
+      <p>Open diagnostic page at <a href="ipfs://bafkreifik2tbj5esf74sf2qwft2x3vuxaqmthwh3d2qx6abpcroirqpt7i" class="f4 link navy hover-teal link underline">ipfs://bafkreifik2tbj5esf74sf2qwft2x3vuxaqmthwh3d2qx6abpcroirqpt7i</a></p>
       <p>It should self-report an unique Origin based on the URL authority component (<code>baf..</code>), as stated in <a href="https://tools.ietf.org/html/rfc2396#section-3.2" class="link navy hover-teal link underline">RFC 2396</a>.</p>
       <p>This is prerequisite for secure sandbox provided by <a href="https://en.wikipedia.org/wiki/Same-origin_policy" class="link navy hover-teal link underline">same-origin policy</a></p>
     </div>

--- a/docs/ipfs-protocol-handler-support-tests.html
+++ b/docs/ipfs-protocol-handler-support-tests.html
@@ -46,6 +46,16 @@
       </ol>
     </div>
 
+
+    <div class='pt4'>
+      <div class='db pb1 w-100 fw2 tracked ttu f3 teal-muted link'>
+        ORIGIN ISOLATION
+      </div>
+      <p>Open diagnostic page at <a href="ipfs://bafkreiatfi5jmy2gzhjr5tixsqntof3pieuyibcbaz3riakaepx4ytoxfu" class="f4 link navy hover-teal link underline">ipfs://bafkreiatfi5jmy2gzhjr5tixsqntof3pieuyibcbaz3riakaepx4ytoxfu</a></p>
+      <p>It should self-report an unique Origin based on the URL authority component (<code>baf..</code>), as stated in <a href="https://tools.ietf.org/html/rfc2396#section-3.2" class="link navy hover-teal link underline">RFC 2396</a>.</p>
+      <p>This is prerequisite for secure sandbox provided by <a href="https://en.wikipedia.org/wiki/Same-origin_policy" class="link navy hover-teal link underline">same-origin policy</a></p>
+    </div>
+
     <div class='pt5'>
       <div class='db pb1 w-100 fw2 tracked ttu f3 teal-muted link'>
         IMG SRC

--- a/docs/origin-check.html
+++ b/docs/origin-check.html
@@ -1,0 +1,34 @@
+ <!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <link rel="stylesheet" href="//unpkg.com/tachyons@4.11.1/css/tachyons.min.css" type="text/css">
+  <link rel="stylesheet" href="//unpkg.com/ipfs-css@0.13.1/ipfs.css" type="text/css">
+  </head>
+
+<body class='sans-serif bg-white'>
+  <section class='pa0 ma0'>
+
+    <div>
+      <p class="ma0 pb2">Values exposed under <code class="bg-snow charcoal">window.location</code>:</p>
+      <ol class='ma0 pa0 list'>
+        <li class="lh-copy">
+          <code class="charcoal">href</code> =
+          <code class="bg-snow charcoal"><script>document.write(window.location.href)</script></code>
+        </li>        
+        <li class="lh-copy">
+          <code class="charcoal">origin</code>=
+          <code class="bg-snow charcoal"><script>document.write(window.location.origin)</script></code>
+        </li>
+        <li class="lh-copy">
+          <code class="charcoal">protocol</code>=
+          <code class="bg-snow charcoal"><script>document.write(window.location.protocol)</script></code>
+        </li>
+      </ol>
+    </div>
+
+  </section>
+
+</body>
+</html>

--- a/docs/origin-check.html
+++ b/docs/origin-check.html
@@ -16,7 +16,7 @@
         <li class="lh-copy">
           <code class="charcoal">href</code> =
           <code class="bg-snow charcoal"><script>document.write(window.location.href)</script></code>
-        </li>        
+        </li>
         <li class="lh-copy">
           <code class="charcoal">origin</code>=
           <code class="bg-snow charcoal"><script>document.write(window.location.origin)</script></code>
@@ -24,6 +24,20 @@
         <li class="lh-copy">
           <code class="charcoal">protocol</code>=
           <code class="bg-snow charcoal"><script>document.write(window.location.protocol)</script></code>
+        </li>
+      </ol>
+      <p class="ma0 pt4 pb2">For reference, expected values for <code class="bg-snow charcoal">ipfs://{cid}</code> URLs are:</p>     <ol class='ma0 pa0 list'>
+        <li class="lh-copy">
+          <code class="charcoal">href</code> =
+          <code class="bg-snow charcoal">ipfs://bafyfoobar/origin-check.html</code>
+        </li>
+        <li class="lh-copy">
+          <code class="charcoal">origin</code>=
+          <code class="bg-snow charcoal">ipfs://bafyfoobar</code>
+        </li>
+        <li class="lh-copy">
+          <code class="charcoal">protocol</code>=
+          <code class="bg-snow charcoal">ipfs:</code>
         </li>
       </ol>
     </div>


### PR DESCRIPTION
This PR adds a short section about diagnostic page at `ipfs://bafkreiatfi5jmy2gzhjr5tixsqntof3pieuyibcbaz3riakaepx4ytoxfu`

It should self-report an unique Origin based on the URL authority component (which in case of `ipfs://` is CID: `baf..`), as stated in [RFC 2396](https://tools.ietf.org/html/rfc2396#section-3.2).

@autonome passing this is a prerequisite for secure sandbox provided by same-origin policy.

Closes #155
