### PR TITLE
docs: link to non-beta docs site

### DIFF
--- a/ADDRESSING.md
+++ b/ADDRESSING.md
@@ -20,7 +20,7 @@
 
 ## TL;DR
 
-If no native protocol handler is available, redirect to a gateway. The implementation should detect if a local IPFS node is available. In web browser contexts where a local IPFS node is present, use [subdomain gateway](https://docs-beta.ipfs.io/how-to/address-ipfs-on-web/#subdomain-gateway) at `localhost`. If not, use public one such as `dweb.link`:
+If no native protocol handler is available, redirect to a gateway. The implementation should detect if a local IPFS node is available. In web browser contexts where a local IPFS node is present, use [subdomain gateway](https://docs.ipfs.io/how-to/address-ipfs-on-web/#subdomain-gateway) at `localhost`. If not, use public one such as `dweb.link`:
 
 ```bash
 ipfs://{cid}                → https://{cid}.ipfs.dweb.link


### PR DESCRIPTION
The legacy IPFS Docs site has been deprecated, so links to `docs-beta.ipfs.io` will auto-redirect to `docs.ipfs.io`. This PR doesn't change much from the user's perspective, but it makes things a bit tidier.