### PR TITLE
docs: clarify subdomain CID normalization

### DIFF
--- a/ADDRESSING.md
+++ b/ADDRESSING.md
@@ -24,7 +24,9 @@ If no native protocol handler is available, redirect to path-based IPFS address 
 
 In both cases point at IPFS path first, to ensure gateway takes care of CID normalization into a DNS-safe form:
 
-```bash
+```
+Native URI            – HTTP Gateway                       (– Internal normalization done by HTTP Gateway)   
+
 ipfs://{cid}          → https://dweb.link/ipfs/{cid}        → HTTP301 → https://{dns-safe-cid}.ipfs.dweb.link
 ipns://{libp2p-key}   → https://dweb.link/ipns/{libp2p-key} → HTTP301 → https://{dns-safe-cid}.ipns.dweb.link
 ```

--- a/ADDRESSING.md
+++ b/ADDRESSING.md
@@ -22,7 +22,7 @@
 
 If no native protocol handler is available, redirect to path-based IPFS address at a gateway. The implementation should detect if a local IPFS node is available. In web browser contexts where a local IPFS node is present, use [subdomain gateway](https://docs.ipfs.io/how-to/address-ipfs-on-web/#subdomain-gateway) at `localhost`. If not, use public one such as `dweb.link`. 
 
-In both cases point at IPFS path first, to ensure gateway takes care of CID normalization into a DNS-safe form:
+In either case, point at IPFS path first to ensure gateway takes care of CID normalization into a DNS-safe form:
 
 ```
 Native URI            – HTTP Gateway                       (– Internal normalization done by HTTP Gateway)   

--- a/ADDRESSING.md
+++ b/ADDRESSING.md
@@ -57,8 +57,8 @@ ipfs://{fqdn-with-dnslink} → redirect → ipns://{fqdn-with-dnslink} # just to
 
 When [origin-based security](https://en.wikipedia.org/wiki/Same-origin_policy) perimeter is needed, [CIDv1](https://github.com/ipld/cid#cidv1) in Base32 ([RFC4648](https://tools.ietf.org/html/rfc4648#section-6), no padding) should be used in subdomain:
 
-    https://<cid>.ipfs.<gateway-host>.tld/path/to/resource
-    https://<libp2p-key-cid>.ipns.<gateway-host>.tld/path/to/resource
+    https://{cid}.ipfs.{gateway-host}/path/to/resource
+    https://{libp2p-key-cid}.ipns.{gateway-host}/path/to/resource
 
 Example:
 
@@ -77,8 +77,8 @@ Read more: [notes on addressing with HTTP](#notes-on-addressing-with-http).
 
 When site isolation does not matter gateway can expose IPFS namespaces as regular URL paths:
 
-    https://<gateway-host>.tld/ipfs/<cid>/path/to/resource
-    https://<gateway-host>.tld/ipns/<keyid_or_fqdn>/path/to/resource
+    https://{gateway-host}/ipfs/{cid}/path/to/resource
+    https://{gateway-host}/ipns/{libp2p-key-or-fqdn}/path/to/resource
 
 Examples:
 
@@ -90,7 +90,7 @@ Examples:
 
 Where possible, subdomain convention should be replaced with native handler that provides the same origin-based guarantees:
 
-    ipfs://{cidv1b32}/path/to/resource
+    ipfs://{cid}/path/to/resource
 
 Example:
 
@@ -154,7 +154,7 @@ HTTP gateway MAY:
 
 Gateway operator MAY work around single Origin limitation by creating artificial
 subdomains based on URL-safe version of root content identifier (eg.
-`<cidv1b32>.ipfs.foo.tld`).  Each subdomain provides separate Origin and creates an
+`{cidv1b32}.ipfs.foo.tld`).  Each subdomain provides separate Origin and creates an
 isolated security context at a cost of obfuscating path-based addressing.
 
 Benefits of this approach:

--- a/ADDRESSING.md
+++ b/ADDRESSING.md
@@ -64,7 +64,7 @@ Example:
 
     https://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq.ipfs.dweb.link/wiki/
 
-Subdomain gateway feature in go-ipfs takes care of necessary CID conversion when IPFS path is requested:
+The subdomain gateway feature in go-ipfs takes care of necessary CID conversion when IPFS path is requested:
 
 ```
 https://dweb.link/ipfs/QmT5NvUtoM5nWFfrQdVrFtvGfKFmG7AHE8P34isapyhCxX/wiki/Mars.html → HTTP 301 

--- a/ADDRESSING.md
+++ b/ADDRESSING.md
@@ -20,7 +20,7 @@
 
 ## TL;DR
 
-If no native protocol handler is available, redirect to IPFS path at a gateway. The implementation should detect if a local IPFS node is available. In web browser contexts where a local IPFS node is present, use [subdomain gateway](https://docs.ipfs.io/how-to/address-ipfs-on-web/#subdomain-gateway) at `localhost`. If not, use public one such as `dweb.link`. 
+If no native protocol handler is available, redirect to path-based IPFS address at a gateway. The implementation should detect if a local IPFS node is available. In web browser contexts where a local IPFS node is present, use [subdomain gateway](https://docs.ipfs.io/how-to/address-ipfs-on-web/#subdomain-gateway) at `localhost`. If not, use public one such as `dweb.link`. 
 
 In both cases point at IPFS path first, to ensure gateway takes care of CID normalization into a DNS-safe form:
 


### PR DESCRIPTION
This PR adds more detail into "best practices" when implementing `ipfs://` URI backed by a subdomain gateway.

Namely, opening a path with CID as-is, to take advantage of DNS normalization built into go-ipfs 0.5+

This should help with native URIs in Brave (https://github.com/brave/brave-browser/issues/10220) when embedded go-ipfs is turned off and other collabs.